### PR TITLE
Auto description

### DIFF
--- a/example/invoke-via-macro.F90
+++ b/example/invoke-via-macro.F90
@@ -28,6 +28,8 @@ program invoke_via_macro
     print *,'Here comes the expected assertion failure:'
     print *
 #endif
+  !call_assert(1+1>2)
+  !call_assert_describe(1+1>2, "Mathematics is broken!")
   call_assert_diagnose(1+1>2,  "example with array diagnostic data" , intrinsic_array_t([1,1,2])) ! false assertion
 
 end program invoke_via_macro

--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -11,7 +11,7 @@
 #define ASSERTIONS 0
 #endif
 
-! Deal with Fortran's stringification debacle:
+! Deal with stringification issues:
 ! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
 #ifndef STRINGIFY
 # ifdef __GFORTRAN__

--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -11,10 +11,20 @@
 #define ASSERTIONS 0
 #endif
 
+! Deal with Fortran's stringification debacle:
+! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
+#ifndef STRINGIFY
+# ifdef __GFORTRAN__
+#  define STRINGIFY(x) "x"
+# else
+#  define STRINGIFY(x) #x
+# endif
+#endif
+
 #if ASSERTIONS
-# define call_assert(assertion) call assert(assertion, "No description provided (see file " // __FILE__ // ", line " // string(__LINE__) // ")")
-# define call_assert_describe(assertion, description) call assert(assertion, description // " in file " // __FILE__ // ", line " // string(__LINE__) // ": " )
-# define call_assert_diagnose(assertion, description, diagnostic_data) call assert(assertion, "file " // __FILE__ // ", line " // string(__LINE__) // ": " // description, diagnostic_data)
+# define call_assert(assertion) call assert(assertion, "call_assert(" // STRINGIFY(assertion) // ") in file " // __FILE__ // ", line " // string(__LINE__))
+# define call_assert_describe(assertion, description) call assert(assertion, description // " in file " // __FILE__ // ", line " // string(__LINE__))
+# define call_assert_diagnose(assertion, description, diagnostic_data) call assert(assertion, description // " in file " // __FILE__ // ", line " // string(__LINE__), diagnostic_data)
 #else
 # define call_assert(assertion)
 # define call_assert_describe(assertion, description)

--- a/src/assert/assert_subroutine_s.F90
+++ b/src/assert/assert_subroutine_s.F90
@@ -31,7 +31,7 @@ contains
         represent_diagnostics_as_string: &
         if (.not. present(diagnostic_data)) then
 
-          trailer = "(none provided)"
+          trailer = ""
 
         else
 
@@ -51,10 +51,11 @@ contains
             class default
               trailer = "of unsupported type."
           end select
+          trailer = ' with diagnostic data "' // trailer // '"'
 
         end if represent_diagnostics_as_string
 
-        error stop header // ' with diagnostic data "' // trailer // '"'
+        error stop header // trailer
 
       end if check_assertion
 


### PR DESCRIPTION
This PR improves assertion output formatting.

The most significant change is the `call_assert(condition)` macro is changed from `No description provided` to a use a stringified version of `condition` as the description.

Example output:

```
call_assert(1+1>2) :
ERROR STOP Assertion "call_assert(1+1>2) in file example/invoke-via-macro.F90, line 31" failed on image 1

call_assert_describe(1+1>2, "Mathematics is broken!") :
ERROR STOP Assertion "Mathematics is broken! in file example/invoke-via-macro.F90, line 32" failed on image 1

call_assert_diagnose(1+1>2,  "example with array diagnostic data" , intrinsic_array_t([1,1,2])) :
ERROR STOP Assertion "example with array diagnostic data in file example/invoke-via-macro.F90, line 33" failed on image 1 with diagnostic data "1           1           2"
```