### PR TITLE
Cray Fortran fixes

### DIFF
--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -14,7 +14,7 @@
 ! Deal with stringification issues:
 ! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
 #ifndef STRINGIFY
-# ifdef __GFORTRAN__
+# if defined(__GFORTRAN__) || defined(_CRAYFTN)
 #  define STRINGIFY(x) "x"
 # else
 #  define STRINGIFY(x) #x

--- a/test/test-assert-macro.F90
+++ b/test/test-assert-macro.F90
@@ -44,6 +44,18 @@ program test_assert_macros
   block
   integer :: computed_checksum = 37, expected_checksum = 37
 
+#if defined(_CRAYFTN)
+  ! Cray Fortran uses different line continuations in macro invocations
+  call_assert_diagnose( computed_checksum == expected_checksum, &
+                      "Checksum mismatch failure!", &
+                      expected_checksum )
+  print *,"  passes with macro-style line breaks"
+
+  call_assert_diagnose( computed_checksum == expected_checksum, & ! ensured since version 3.14
+                        "Checksum mismatch failure!",           & ! TODO: write a better message here 
+                        computed_checksum )
+  print *,"  passes with C block comments embedded in macro"
+#else
   call_assert_diagnose( computed_checksum == expected_checksum, \
                       "Checksum mismatch failure!", \
                       expected_checksum )
@@ -53,6 +65,7 @@ program test_assert_macros
                         "Checksum mismatch failure!",           /* TODO: write a better message here */ \
                         computed_checksum )
   print *,"  passes with C block comments embedded in macro"
+#endif
 
   end block
 


### PR DESCRIPTION
Repair _some_ of the problems currently preventing use of this library with CCE 17.0.0.

These changes are necessary, but not sufficient to pass `fpm test`.

Specifically, test/test-intrinsic_array remains broken due to NERSC INC0216109 aka HPE Case # 5374395266 