### PR TITLE
Fix issue #46: workaround some compile errors with flang-new 19.1.1

### DIFF
--- a/example/derived-type_diagnostic.F90
+++ b/example/derived-type_diagnostic.F90
@@ -43,9 +43,12 @@ module stuff_m
 
 contains
 
-  module procedure defined
+  pure module function defined(self) result(self_defined)
+    class(stuff_t), intent(in) :: self
+    logical self_defined
+
     self_defined = self%defined_
-  end procedure
+  end function
 
   module procedure construct
     new_stuff_t%z_ = z
@@ -103,12 +106,15 @@ module characterizable_stuff_m
   
 contains
 
-  module procedure as_character
+  pure module function as_character(self) result(character_self)
+      class(characterizable_stuff_t), intent(in) :: self
+      character(len=:), allocatable :: character_self
+
     integer, parameter :: max_len=256
     character(len=max_len) untrimmed_string
     write(untrimmed_string,*) self%stuff_%z()
     character_self = trim(adjustl(untrimmed_string))
-  end procedure
+  end function
 
   module procedure construct
     new_characterizable_stuff%stuff_ = stuff

--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -14,7 +14,7 @@
 ! Deal with stringification issues:
 ! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
 #ifndef STRINGIFY
-# if defined(__GFORTRAN__) || defined(_CRAYFTN)
+# if defined(__GFORTRAN__) || defined(_CRAYFTN) || defined(NAGFOR)
 #  define STRINGIFY(x) "x"
 # else
 #  define STRINGIFY(x) #x


### PR DESCRIPTION

I don't really understand why this change works, but it resolves the compile errors in my testing.  I suspect this might represent a defect in flang-new.