### PR TITLE
Interface and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,13 @@ fpm test --compiler ifx --profile release --flag "-coarray -DASSERT_MULTI_IMAGE"
 ```
 
 ### Building and testing with the LLVM `flang-new` compiler
+#### LLVM 19 Version
 ```
 fpm test --compiler flang-new --flag "-mmlir -allow-assumed-rank -O3"
+```
+#### LLVM 20 or later
+```
+fpm test --compiler flang-new --flag "-O3"
 ```
 
 ### Building and testing with the Numerical Algorithms Group (NAG) compiler

--- a/include/assert_macros.h
+++ b/include/assert_macros.h
@@ -13,18 +13,18 @@
 
 ! Deal with stringification issues:
 ! https://gcc.gnu.org/legacy-ml/fortran/2009-06/msg00131.html
-#ifndef STRINGIFY
+#ifndef CPP_STRINGIFY_SOURCE
 # if defined(__GFORTRAN__) || defined(_CRAYFTN) || defined(NAGFOR)
-#  define STRINGIFY(x) "x"
+#  define CPP_STRINGIFY_SOURCE(x) "x"
 # else
-#  define STRINGIFY(x) #x
+#  define CPP_STRINGIFY_SOURCE(x) #x
 # endif
 #endif
 
 #if ASSERTIONS
-# define call_assert(assertion) call assert_always(assertion, "call_assert(" // STRINGIFY(assertion) // ") in file " // __FILE__ // ", line " // string(__LINE__))
-# define call_assert_describe(assertion, description) call assert_always(assertion, description // " in file " // __FILE__ // ", line " // string(__LINE__))
-# define call_assert_diagnose(assertion, description, diagnostic_data) call assert_always(assertion, description // " in file " // __FILE__ // ", line " // string(__LINE__), diagnostic_data)
+# define call_assert(assertion) call assert_always(assertion, "call_assert(" // CPP_STRINGIFY_SOURCE(assertion) // ") in file " // __FILE__ // ", line " // fortran_stringify_integer(__LINE__))
+# define call_assert_describe(assertion, description) call assert_always(assertion, description // " in file " // __FILE__ // ", line " // fortran_stringify_integer(__LINE__))
+# define call_assert_diagnose(assertion, description, diagnostic_data) call assert_always(assertion, description // " in file " // __FILE__ // ", line " // fortran_stringify_integer(__LINE__), diagnostic_data)
 #else
 # define call_assert(assertion)
 # define call_assert_describe(assertion, description)

--- a/src/assert/fortran_stringify_integer_m.f90
+++ b/src/assert/fortran_stringify_integer_m.f90
@@ -1,16 +1,16 @@
-module string_m
+module fortran_stringify_integer_m
   implicit none
 
 contains  
 
-   pure function string(number) result(number_as_string)
+  pure function fortran_stringify_integer(number) result(number_as_string)
     integer, intent(in) :: number
     integer, parameter :: max_len=128
     character(len=max_len) :: untrimmed_string
     character(len=:), allocatable :: number_as_string
 
-    write(untrimmed_string, *) number
+    write(untrimmed_string, '(i0)') number
     number_as_string = trim(adjustl(untrimmed_string))
   end function
 
-end module string_m
+end module

--- a/src/assert_m.f90
+++ b/src/assert_m.f90
@@ -1,7 +1,15 @@
 module assert_m
-  use intrinsic_array_m, only : intrinsic_array_t
+  !! Public interface
+  use intrinsic_array_m,   only : intrinsic_array_t
   use assert_subroutine_m, only : assert, assert_always
-  use characterizable_m, only : characterizable_t
+  use characterizable_m,   only : characterizable_t
+
+  ! The function below is public only to support automated
+  ! invocation via `assert_macros.h`.  For a more broadly useful
+  ! function to convert numeric data to string format, please
+  ! consider using the functions that can be accessed via the 
+  ! `string_t` generic interface in the Julienne framework at
+  ! https://go.lbl.gov/julienne.
   use fortran_stringify_integer_m, only : fortran_stringify_integer
   implicit none
 end module

--- a/src/assert_m.f90
+++ b/src/assert_m.f90
@@ -1,7 +1,7 @@
 module assert_m
-  use intrinsic_array_m
-  use assert_subroutine_m
-  use characterizable_m
-  use string_m, only : string
+  use intrinsic_array_m, only : intrinsic_array_t
+  use assert_subroutine_m, only : assert, assert_always
+  use characterizable_m, only : characterizable_t
+  use fortran_stringify_integer_m, only : fortran_stringify_integer
   implicit none
-end module assert_m
+end module


### PR DESCRIPTION
This pull request accomplishes the following: 
1. Updates the README.md file to explain that two experimental flags required with LLVM 19 are not required with LLVM 20.
2. Renames the `string_m` module and `string` function to `fortran_stringify_integer_m` and `fortran_stringify_integer`, respectively, to decrease the likelihood of name clashes with user code and to clarify the function's limited purpose.
3. Adds comments to the `assert_m` module to clarify the purpose of the `fortran_stringify_integer` function and refer users to Julienne for a more broadly useful stringification capability.
4. Renames the `STRINGIFY` macro to `CPP_STRINGIFY_SOURCE` to clarify the difference from `fortran_stringify_integer` and reduce the likelihood of name clashes with user code.
5.  Changes the `fortran_stringify_integer` string-writing format from `*` to `(i0)` for more consistent results across compilers. The results are the same for the three tested compilers: GCC (`gfortran`), NAG (`nagfor`), and LLVM (`flang-new`).