### PR TITLE
CI expansion in GitHub Actions

### DIFF
--- a/.github/workflows/build-gfortran.yml
+++ b/.github/workflows/build-gfortran.yml
@@ -1,18 +1,26 @@
-name: Build with gfortran12
+name: Build with gfortran
 
 on: [push, pull_request]
 
 
 jobs:
-  gfortran12-build:
+  gfortran-build:
+    name: gfortran-${{ matrix.gcc_version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-13, ubuntu-22.04, ubuntu-24.04]
+        gcc_version: [ 12, 13, 14 ]
+        exclude:
+          - os: ubuntu-22.04
+            gcc_version: 13 # no package available
+          - os: ubuntu-22.04
+            gcc_version: 14 # no package available
 
     env:
-      GCC_V: 12
-      FPM_FC: gfortran-12
+      GCC_V: ${{ matrix.gcc_version }}
+      FPM_FC: gfortran-${{ matrix.gcc_version }}
       EXTRA_FLAGS: -ffree-line-length-0
 
     steps:
@@ -24,9 +32,10 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install Dependencies Ubuntu
-      if: contains(matrix.os, 'ubuntu')
+      if: contains(matrix.os, 'ubuntu') && 0
       run: |
         sudo apt-get update
+        sudo apt list -a 'gfortran-*'
         sudo apt install -y gfortran-${GCC_V} build-essential
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
         --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \

--- a/.github/workflows/build-gfortran12.yml
+++ b/.github/workflows/build-gfortran12.yml
@@ -5,7 +5,10 @@ on: [push, pull_request]
 
 jobs:
   gfortran12-build:
-    runs-on: [ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
 
     env:
       GCC_V: 12
@@ -34,21 +37,26 @@ jobs:
         set -x
         echo == TOOL VERSIONS ==
         uname -a
-        cat /etc/os-release
+        if test -r /etc/os-release ; then cat /etc/os-release ; fi
         ${FPM_FC} --version
         fpm --version
 
     - name: Build and Test (Assertions OFF)
       env: 
-        FC_FLAGS: ${EXTRA_FLAGS}
+        FPM_FLAGS:  --profile release --flag ${{ env.EXTRA_FLAGS }}
       run: |
         set -x
-        fpm test --verbose --profile release --flag "${FC_FLAGS}"
+        fpm test --verbose ${FPM_FLAGS}
+        fpm run --verbose --example false-assertion ${FPM_FLAGS}
+        fpm run --verbose --example invoke-via-macro ${FPM_FLAGS}
 
     - name: Build and Test (Assertions ON)
       env: 
-        FC_FLAGS: ${EXTRA_FLAGS} -DASSERTIONS
+        FPM_FLAGS:  --profile release --flag ${{ env.EXTRA_FLAGS }} --flag -DASSERTIONS
       run: |
         set -x
-        fpm test --verbose --profile release --flag "${FC_FLAGS}"
+        fpm test --verbose ${FPM_FLAGS}
+        ( set +e ; fpm run --verbose --example false-assertion ${FPM_FLAGS} ; test $? = 1 )
+        ( set +e ; fpm run --verbose --example invoke-via-macro ${FPM_FLAGS} ; test $? = 1 )
+
 

--- a/.github/workflows/build-gfortran12.yml
+++ b/.github/workflows/build-gfortran12.yml
@@ -1,15 +1,16 @@
-name: CI
+name: Build with gfortran12
 
 on: [push, pull_request]
 
 
 jobs:
-  Build:
+  gfortran12-build:
     runs-on: [ubuntu-22.04]
 
     env:
-      FC: gfortran
       GCC_V: 12
+      FPM_FC: gfortran-12
+      EXTRA_FLAGS: -ffree-line-length-0
 
     steps:
     - name: Checkout code
@@ -28,6 +29,26 @@ jobs:
         --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
         --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
 
-    - name: Build and Test
+    - name: Version info
       run: |
-        fpm test --profile release --flag -ffree-line-length-0
+        set -x
+        echo == TOOL VERSIONS ==
+        uname -a
+        cat /etc/os-release
+        ${FPM_FC} --version
+        fpm --version
+
+    - name: Build and Test (Assertions OFF)
+      env: 
+        FC_FLAGS: ${EXTRA_FLAGS}
+      run: |
+        set -x
+        fpm test --verbose --profile release --flag "${FC_FLAGS}"
+
+    - name: Build and Test (Assertions ON)
+      env: 
+        FC_FLAGS: ${EXTRA_FLAGS} -DASSERTIONS
+      run: |
+        set -x
+        fpm test --verbose --profile release --flag "${FC_FLAGS}"
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,25 @@ jobs:
         os: [macos-13, macos-14, ubuntu-22.04, ubuntu-24.04]
         compiler: [ gfortran ]
         version: [ 12, 13, 14 ]
-        extra_flags: [ -ffree-line-length-0 ]
+        extra_flags: [ '"-ffree-line-length-0"' ]
         include:
+          # https://hub.docker.com/r/phhargrove/llvm-flang/tags
           - os: ubuntu-24.04
             compiler: flang
-            version: new
-            container: gmao/llvm-flang:latest
-            extra_flags: -g
+            version: 20
+            extra_flags: '"-g"'
+            container: phhargrove/llvm-flang:20.1.0-1
+          - os: ubuntu-24.04
+            compiler: flang
+            version: 19
+            extra_flags: '[ "-g", "-mmlir", "-allow-assumed-rank" ]'
+            container: phhargrove/llvm-flang:19.1.1-1
+#          - os: ubuntu-24.04
+#            compiler: flang
+#            version: new
+#            container: gmao/llvm-flang:latest
+#            extra_flags: -g
+
         exclude:
           - os: ubuntu-22.04
             version: 13 # no package available
@@ -30,25 +42,34 @@ jobs:
       image: ${{ matrix.container }}
 
     env:
-      GCC_V: ${{ matrix.version }}
-      FPM_FC: ${{ matrix.compiler }}-${{ matrix.version }}
-      EXTRA_FLAGS: ${{ matrix.extra_flags }}
+      GCC_VERSION: ${{ matrix.version }}
+      FC: ${{ matrix.compiler }}
+      EXTRA_FLAGS: ${{ join(fromJSON(matrix.extra_flags), ' --flag ') }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Install Dependencies Ubuntu
-      if: contains(matrix.os, 'ubuntu') && 0
+      if: ${{ contains(matrix.os, 'ubuntu') && matrix.compiler == 'gfortran' && 0 }}
       run: |
         sudo apt-get update
         sudo apt list -a 'gfortran-*'
-        sudo apt install -y gfortran-${GCC_V} build-essential
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
-        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
-        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+        sudo apt install -y gfortran-${GCC_VERSION} build-essential
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 \
+        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_VERSION}
 
-    - uses: fortran-lang/setup-fpm@main
+    - name: Setup Compilers
+      run: |
+        set -x
+        if test "$FC" = "flang" ; then \
+          echo "FPM_FC=flang-new" >> "$GITHUB_ENV" ; \
+        else \
+          echo "FPM_FC=gfortran-${GCC_VERSION}" >> "$GITHUB_ENV" ; \
+        fi
+
+    - name: Setup FPM
+      uses: fortran-lang/setup-fpm@main
       if: ${{ matrix.os != 'macos-14' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,38 @@
-name: Build with gfortran
+name: Build
 
 on: [push, pull_request]
 
 
 jobs:
-  gfortran-build:
-    name: gfortran-${{ matrix.gcc_version }} (${{ matrix.os }})
+  build:
+    name: ${{ matrix.compiler }}-${{ matrix.version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-13, ubuntu-22.04, ubuntu-24.04]
-        gcc_version: [ 12, 13, 14 ]
+        compiler: [ gfortran ]
+        version: [ 12, 13, 14 ]
+        extra_flags: [ -ffree-line-length-0 ]
+        include:
+          - os: ubuntu-24.04
+            compiler: flang
+            version: new
+            container: gmao/llvm-flang:latest
+            extra_flags: -g
         exclude:
           - os: ubuntu-22.04
-            gcc_version: 13 # no package available
+            version: 13 # no package available
           - os: ubuntu-22.04
-            gcc_version: 14 # no package available
+            version: 14 # no package available
+
+    container:
+      image: ${{ matrix.container }}
 
     env:
-      GCC_V: ${{ matrix.gcc_version }}
-      FPM_FC: gfortran-${{ matrix.gcc_version }}
-      EXTRA_FLAGS: -ffree-line-length-0
+      GCC_V: ${{ matrix.version }}
+      FPM_FC: ${{ matrix.compiler }}-${{ matrix.version }}
+      EXTRA_FLAGS: ${{ matrix.extra_flags }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-22.04, ubuntu-24.04]
+        os: [macos-13, macos-14, ubuntu-22.04, ubuntu-24.04]
         compiler: [ gfortran ]
         version: [ 12, 13, 14 ]
         extra_flags: [ -ffree-line-length-0 ]
@@ -38,10 +38,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - uses: fortran-lang/setup-fpm@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Install Dependencies Ubuntu
       if: contains(matrix.os, 'ubuntu') && 0
       run: |
@@ -51,6 +47,20 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
         --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
         --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+
+    - uses: fortran-lang/setup-fpm@main
+      if: ${{ matrix.os != 'macos-14' }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build FPM
+      if: ${{ matrix.os == 'macos-14' }} # no arm64 fpm distro, build from source
+      run: |
+        set -x
+        curl --retry 5 -LOsS https://github.com/fortran-lang/fpm/releases/download/v0.11.0/fpm-0.11.0.F90
+        mkdir fpm-temp
+        gfortran-14 -o fpm-temp/fpm fpm-0.11.0.F90
+        echo "PATH=`pwd`/fpm-temp:${PATH}" >> "$GITHUB_ENV"
 
     - name: Version info
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,18 +13,18 @@ jobs:
         os: [macos-13, macos-14, ubuntu-22.04, ubuntu-24.04]
         compiler: [ gfortran ]
         version: [ 12, 13, 14 ]
-        extra_flags: [ '"-ffree-line-length-0"' ]
+        extra_flags: [ -ffree-line-length-0 ]
         include:
           # https://hub.docker.com/r/phhargrove/llvm-flang/tags
           - os: ubuntu-24.04
             compiler: flang
             version: 20
-            extra_flags: '"-g"'
+            extra_flags: -g
             container: phhargrove/llvm-flang:20.1.0-1
           - os: ubuntu-24.04
             compiler: flang
             version: 19
-            extra_flags: '[ "-g", "-mmlir", "-allow-assumed-rank" ]'
+            extra_flags: -g -mmlir -allow-assumed-rank
             container: phhargrove/llvm-flang:19.1.1-1
 #          - os: ubuntu-24.04
 #            compiler: flang
@@ -44,7 +44,7 @@ jobs:
     env:
       GCC_VERSION: ${{ matrix.version }}
       FC: ${{ matrix.compiler }}
-      EXTRA_FLAGS: ${{ join(fromJSON(matrix.extra_flags), ' --flag ') }}
+      FPM_FLAGS:  --profile release --verbose
 
     steps:
     - name: Checkout code
@@ -93,21 +93,19 @@ jobs:
         fpm --version
 
     - name: Build and Test (Assertions OFF)
-      env: 
-        FPM_FLAGS:  --profile release --flag ${{ env.EXTRA_FLAGS }}
       run: |
         set -x
-        fpm test --verbose ${FPM_FLAGS}
-        fpm run --verbose --example false-assertion ${FPM_FLAGS}
-        fpm run --verbose --example invoke-via-macro ${FPM_FLAGS}
+        fpm test                              ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}"
+        fpm run  --example false-assertion    ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}"
+        fpm run  --example invoke-via-macro   ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}"
 
     - name: Build and Test (Assertions ON)
-      env: 
-        FPM_FLAGS:  --profile release --flag ${{ env.EXTRA_FLAGS }} --flag -DASSERTIONS
+      env:
+        FPM_FLAGS: ${{ env.FPM_FLAGS }} --flag -DASSERTIONS
       run: |
         set -x
-        fpm test --verbose ${FPM_FLAGS}
-        ( set +e ; fpm run --verbose --example false-assertion ${FPM_FLAGS} ; test $? = 1 )
-        ( set +e ; fpm run --verbose --example invoke-via-macro ${FPM_FLAGS} ; test $? = 1 )
+                   fpm test                            ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}"
+        ( set +e ; fpm run  --example false-assertion  ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}" ; test $? = 1 )
+        ( set +e ; fpm run  --example invoke-via-macro ${FPM_FLAGS} --flag "${{ matrix.EXTRA_FLAGS }}" ; test $? = 1 )
 
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 
 jobs:
-  Build:
+  build:
+    name: Build and Deploy Documentation
     runs-on: ubuntu-22.04
 
     env:

--- a/test/run-false-assertion.sh
+++ b/test/run-false-assertion.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 output=$(fpm run --example false-assertion --compiler flang-new --flag '-mmlir -allow-assumed-rank -O3 -DASSERTIONS' > /dev/null 2>&1)
-echo $?
+echo $? > build/exit_status

--- a/test/test-assert-subroutine-error-termination.F90
+++ b/test/test-assert-subroutine-error-termination.F90
@@ -21,7 +21,7 @@ program test_assert_subroutine_error_termination
 #elif NAGFOR
     command = "fpm run --example false-assertion --compiler nagfor --flag '-DASSERTIONS -fpp' > /dev/null 2>&1", &
 #elif __flang__
-    command = "./test/run-false-assertion.sh | fpm run --example check-exit-status", &
+    command = "./test/run-false-assertion.sh", &
 #elif __INTEL_COMPILER
     command = "./test/run-false-assertion-intel.sh | fpm run --example check-exit-status", &
 #elif _CRAYFTN


### PR DESCRIPTION
This PR greatly expands our CI coverage in GitHub Actions. The actions now cover:

* gfortran-{12,13,14} on ubuntu-24.04, macos-13-x86_64, macos-14-arm64
* gfortran-12 on ubuntu-22.04
* flang-{19.1.1,20.1.0} on ubuntu-24.04

In addition, we now `fpm test` both with and without `-DASSERTIONS`, and additionally run two of the examples.


