### PR TITLE
Reduce the manifest

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,10 +1,4 @@
 name = "assert"
-version = "2.0.0"
-license = "BSD"
-author = ["Damian Rouson", "Dan Bonachea"]
-maintainer = "rouson@lbl.gov"
-copyright = "2024-2025 The Regents of the University of California, through Lawrence Berkeley National Laboratory"
 
 [install]
 library = true
-


### PR DESCRIPTION
This PR removes information from `fpm.toml` that is redundant with data elsewhere in the repository and unnecessary for building and use.